### PR TITLE
Fix compilation for TankBot

### DIFF
--- a/Bot/TankBot.cmd
+++ b/Bot/TankBot.cmd
@@ -1,1 +1,1 @@
-java -cp ../lib/* TankBot.java
+java -cp "lib/*;src" TankBot

--- a/Bot/compile.bat
+++ b/Bot/compile.bat
@@ -3,7 +3,7 @@ REM Compile all Java source files for the bot
 
 set CLASSPATH=.;lib\*
 
-javac -cp %CLASSPATH% src\TankBot.java src\TargetLocator.java
+javac --release 11 -cp %CLASSPATH% src\TankBot.java src\TargetLocator.java
 if %ERRORLEVEL% neq 0 (
     echo Failed to compile.
     exit /b %ERRORLEVEL%

--- a/Bot/src/TankBot.java
+++ b/Bot/src/TankBot.java
@@ -49,7 +49,7 @@ public class TankBot extends Bot {
     @Override
     public void onHitByBullet(HitByBulletEvent e) {
         // Calculate the bearing to the direction of the bullet
-        var bearing = calcBearing(e.getBullet().getDirection());
+        double bearing = calcBearing(e.getBullet().getDirection());
 
         // Turn 90 degrees to the bullet direction based on the bearing
         turnRight(90 - bearing);

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Simple and fun Robocode Bot Demo
 
 ## Building
 
-Use `compile.bat` to compile the Java sources on Windows:
+Use `compile.bat` (requires Java 11 or newer) to compile the Java sources on Windows:
 
 ```bat
 compile.bat
@@ -11,3 +11,13 @@ compile.bat
 
 This script compiles `TankBot.java` and `TargetLocator.java` using the
 libraries found in the `lib` folder one level above this project.
+
+## Running
+
+After compiling, run the bot using `TankBot.cmd`:
+
+```cmd
+TankBot.cmd
+```
+
+This command starts the bot with the compiled classes and included library.


### PR DESCRIPTION
## Summary
- fix the var declaration so Java 8 compilers do not fail
- ensure compile.bat compiles with Java 11
- correct run command in TankBot.cmd
- document build and run instructions

## Testing
- `javac --release 11 -cp Bot/lib/* Bot/src/TankBot.java Bot/src/TargetLocator.java`

------
https://chatgpt.com/codex/tasks/task_e_68509bcbd9ac832ba7f89368d742d516