### PR TITLE
Implement fixed square path start

### DIFF
--- a/Bot/src/TankBot.java
+++ b/Bot/src/TankBot.java
@@ -28,14 +28,38 @@ public class TankBot extends Bot {
     // Called when a new round is started -> initialize and do some movement
     @Override
     public void run() {
-        // Move in a square pattern while searching for enemies
+        // Calculate a reference position about 100px from the middle towards the top left
+        double centerX = getArenaWidth() / 2.0;
+        double centerY = getArenaHeight() / 2.0;
+        double startX = centerX - 100;
+        double startY = centerY - 100;
+
+        // Move from the spawn point to the reference start position
+        goTo(startX, startY);
+
+        // Continuously move in a square of 100x100 pixels while searching for enemies
         while (isRunning()) {
-            for (int i = 0; i < 4; i++) {
-                forward(150);
-                locator.findTarget();
-                turnRight(90);
-            }
+            goTo(startX + 100, startY);       // Right
+            locator.findTarget();
+            goTo(startX + 100, startY + 100); // Down
+            locator.findTarget();
+            goTo(startX, startY + 100);       // Left
+            locator.findTarget();
+            goTo(startX, startY);             // Up (back to start)
+            locator.findTarget();
         }
+    }
+
+    /**
+     * Helper method to move the bot to an absolute coordinate.
+     *
+     * @param x target x coordinate
+     * @param y target y coordinate
+     */
+    private void goTo(double x, double y) {
+        double bearing = bearingTo(x, y);
+        turnRight(bearing);
+        forward(distanceTo(x, y));
     }
 
     // We saw another bot -> fire!


### PR DESCRIPTION
## Summary
- orient the bot at a fixed location 100px up/left from the arena center
- follow a 100x100px square path from that position
- add a helper `goTo` method used for absolute moves

## Testing
- `javac --release 11 -cp "Bot/lib/*" Bot/src/TankBot.java Bot/src/TargetLocator.java`

------
https://chatgpt.com/codex/tasks/task_e_6851b3af1e34832ba58fe07c9b36dc2d