### PR TITLE
Add launcher error handling

### DIFF
--- a/Bot/infinite/mind/TankBotLauncher.java
+++ b/Bot/infinite/mind/TankBotLauncher.java
@@ -17,6 +17,14 @@ public class TankBotLauncher {
             secret = "";
         }
         TankBot bot = new TankBot(url, secret);
-        bot.start();
+        try {
+            bot.start();
+            JOptionPane.showMessageDialog(null, "Bot finished running.", "Info", JOptionPane.INFORMATION_MESSAGE);
+        } catch (Exception e) {
+            JOptionPane.showMessageDialog(null,
+                    "Failed to run bot: " + e.getMessage(),
+                    "Error", JOptionPane.ERROR_MESSAGE);
+            e.printStackTrace();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- show message dialogs after running the bot
- notify users when the bot fails to start

## Testing
- `./scripts/generate_docs.sh` *(passes)*
- `javac -cp ../../lib/*:. TankBotLauncher.java TankBot.java TargetLocator.java learning.java`

------
https://chatgpt.com/codex/tasks/task_e_6855d0ecffd0832b838b4e34acf5cb9b